### PR TITLE
Rename 'length/1' to 'distance' for clarity

### DIFF
--- a/lib/basalt.ex
+++ b/lib/basalt.ex
@@ -104,6 +104,17 @@ defmodule Basalt.Hex do
   end
 
   @doc """
+  The distance ("length") between a given Hex and the hexagonal grid's
+  origin.
+
+  Returns an integer representing the tile "steps" from origin.
+  """
+  @spec distance(t) :: integer
+  def distance(%Hex{} = hex) do
+    round((abs(hex.q) + abs(hex.r) + abs(hex.s)) / 2)
+  end
+
+  @doc """
   The distance between two hexes is the "length" between the two
   hexes.
 
@@ -111,18 +122,7 @@ defmodule Basalt.Hex do
   """
   @spec distance(t, t) :: non_neg_integer
   def distance(%Hex{} = a, %Hex{} = b) do
-    Hex.length(subtract(a, b))
-  end
-
-  @doc """
-  "Length" represents the tile distance between a given Hex and the
-  hexagonal grid's origin.
-
-  Returns an integer representing the tile "steps" from origin.
-  """
-  @spec length(t) :: non_neg_integer
-  def length(%Hex{} = hex) do
-    round((abs(hex.q) + abs(hex.r) + abs(hex.s)) / 2)
+    Hex.distance(subtract(a, b))
   end
 
   @doc """
@@ -184,7 +184,7 @@ defmodule Basalt.Hex do
   """
   @spec neighbor?(t, t) :: boolean
   def neighbor?(%Hex{} = hex_a, %Hex{} = hex_b) do
-    Hex.length(subtract(hex_a, hex_b)) == 1
+    distance(hex_a, hex_b) == 1
   end
 
   @doc """

--- a/test/basalt_test.exs
+++ b/test/basalt_test.exs
@@ -58,11 +58,11 @@ defmodule BasaltTest do
     end
   end
 
-  describe "Hex.length/2" do
-    test "returns the length of a hex" do
+  describe "Hex.distance/1" do
+    test "returns the distance of a hex from origin" do
       hex_a = Hex.create!(1, 1, -2)
 
-      assert Hex.length(hex_a) == 2
+      assert Hex.distance(hex_a) == 2
     end
   end
 


### PR DESCRIPTION
The previous function `length/1` represents the "length (distance) from the hexagonal map's origin. Renaming this to prevent confusion with other Elixir `length/1` functions and to be more descriptive to its purpose.